### PR TITLE
Removed includes, added set path method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ Makefile.in
 
 /src/vcc_if.c
 /src/vcc_if.h
+
+.idea/

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Varnish IP2Location Module
 
 :Author: Thomas Lecomte
 :Date: 2015-04-29
-:Version: 1.1
+:Version: 2
 :Manual section: 3
 
 SYNOPSIS

--- a/src/vmod_ip2location.c
+++ b/src/vmod_ip2location.c
@@ -5,10 +5,7 @@
 #include <pthread.h>
 #include <IP2Location.h>
 
-#include "vcl.h"
-#include "vrt.h"
 #include "cache/cache.h"
-#include "vcc_if.h"
 #include "vmod_ip2location.h"
 
 #define VMOD_LOG(...) VSLb(ctx->vsl, SLT_VCL_Log, __VA_ARGS__);
@@ -73,7 +70,6 @@ event_handler(VRT_CTX, struct vmod_priv *priv, enum vcl_event_e e)
 		break;
 	case VCL_EVENT_WARM:
 	case VCL_EVENT_COLD:
-	case VCL_EVENT_USE:
 	default:
 		break;
 	}

--- a/src/vmod_ip2location.c
+++ b/src/vmod_ip2location.c
@@ -10,7 +10,7 @@
 
 #define VMOD_LOG(...) VSLb(ctx->vsl, SLT_VCL_Log, __VA_ARGS__);
 
-char * path = IP2LOCATION_DB_PATH;
+char * path = NULL;
 
 void
 i2pl_free(void *d)

--- a/src/vmod_ip2location.c
+++ b/src/vmod_ip2location.c
@@ -79,7 +79,7 @@ event_handler(VRT_CTX, struct vmod_priv *priv, enum vcl_event_e e)
 }
 
 VCL_VOID
-vmod_set_path(const struct vrt_ctx *ctx, struct vmod_priv *priv, const char *new_path)
+vmod_set_path(VRT_CTX, struct vmod_priv *priv, const char *new_path)
 {
     path = (char *) new_path;
 }

--- a/src/vmod_ip2location.h
+++ b/src/vmod_ip2location.h
@@ -5,4 +5,4 @@ typedef struct vmod_ip2location_data {
 } ip2location_data_t;
 
 /* FIXME: put this in a variable/config/default file */
-#define IP2LOCATION_DB_PATH "/etc/varnish/IP2LOCATION.BIN"
+#define IP2LOCATION_DB_PATH "/usr/lib/ip2location/IP2LOCATION.BIN"

--- a/src/vmod_ip2location.h
+++ b/src/vmod_ip2location.h
@@ -3,6 +3,3 @@ typedef struct vmod_ip2location_data {
   IP2Location		*ip2l_handle;
   pthread_mutex_t	lock;
 } ip2location_data_t;
-
-/* FIXME: put this in a variable/config/default file */
-#define IP2LOCATION_DB_PATH "/usr/lib/ip2location/IP2LOCATION.BIN"

--- a/src/vmod_ip2location.h
+++ b/src/vmod_ip2location.h
@@ -5,4 +5,4 @@ typedef struct vmod_ip2location_data {
 } ip2location_data_t;
 
 /* FIXME: put this in a variable/config/default file */
-#define IP2LOCATION_DB_PATH "/usr/lib/ip2location/IP2LOCATION.BIN"
+#define IP2LOCATION_DB_PATH "/etc/varnish/IP2LOCATION.BIN"

--- a/src/vmod_ip2location.vcc
+++ b/src/vmod_ip2location.vcc
@@ -1,4 +1,5 @@
 $Module ip2location 3 IP2Location module
 $Event event_handler
+$Function VOID set_path(PRIV_VCL, STRING)
 $Function STRING country_short(PRIV_VCL, STRING)
 $Function STRING region(PRIV_VCL, STRING)


### PR DESCRIPTION
To make the VMOD work with Varnish 6.1 I had to remove the vcl.h, vrt.h and vcc_if.h includes. I also added a method to set the path of the database file.